### PR TITLE
Presence of unset should not lead to a fatal error

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,6 +21,12 @@ How to run it
 
 Then get a failure and contribute here with a PR to workaround the issue you got :)
 
+Launch tests with the following command:
+
+```bash
+vendor/bin/phpunit --configuration phpunit.xml
+```
+
 How
 ---
 

--- a/src/SimpleTestToMockeryVisitor.php
+++ b/src/SimpleTestToMockeryVisitor.php
@@ -226,7 +226,8 @@ class SimpleTestToMockeryVisitor extends NodeVisitorAbstract
         if ($node instanceof Node\Stmt\ClassMethod && $node->name->name === 'setUp') {
             $setup_found = false;
             foreach ($node->stmts as $stmt) {
-                if ($stmt->expr instanceof Node\Expr\StaticCall &&
+                if (isset($stmt->expr) &&
+                    $stmt->expr instanceof Node\Expr\StaticCall &&
                     $stmt->expr->class->parts[0] === 'parent' &&
                     $stmt->expr->name->name === 'setUp'
                 ) {
@@ -252,7 +253,8 @@ class SimpleTestToMockeryVisitor extends NodeVisitorAbstract
         if ($node instanceof Node\Stmt\ClassMethod && $node->name->name === 'tearDown') {
             $teardown_found = false;
             foreach ($node->stmts as $stmt) {
-                if ($stmt->expr instanceof Node\Expr\StaticCall &&
+                if (isset($stmt->expr) &&
+                    $stmt->expr instanceof Node\Expr\StaticCall &&
                     $stmt->expr->class->parts[0] === 'parent' &&
                     $stmt->expr->name->name === 'tearDown'
                 ) {

--- a/tests/_expected/SetUpTearDownTest.php
+++ b/tests/_expected/SetUpTearDownTest.php
@@ -25,12 +25,13 @@ class SetUpTearDownTest
         parent::setUp();
         // initialize stuff
         $this->stuff = 'foo';
+        unset($this->previous);
     }
 
     public function tearDown()
     {
         // clean
-        $this->stuff = '';
+        unset($this->stuff);
         parent::tearDown();
     }
 }

--- a/tests/_fixtures/SetUpTearDownTest.php
+++ b/tests/_fixtures/SetUpTearDownTest.php
@@ -24,11 +24,12 @@ class SetUpTearDownTest
     {
         // initialize stuff
         $this->stuff = 'foo';
+        unset($this->previous);
     }
 
     public function tearDown()
     {
         // clean
-        $this->stuff = '';
+        unset($this->stuff);
     }
 }


### PR DESCRIPTION
When you have a call to unset() in a tearDown() or in a setUp(), the
conversion should not fail.

```php
public function tearDown()
{
  unset($this->vars);
}
```