### PR TITLE
Use always/expects syntax and fluent style

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,4 +7,9 @@
             <exclude>tests/_expected</exclude>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/src/ST2Mockery.php
+++ b/src/ST2Mockery.php
@@ -103,7 +103,7 @@ class ST2Mockery
 
     public function save(string $path)
     {
-        $printer = new PrettyPrinter\Standard();
+        $printer = new PrettyPrinter\Standard(['shortArraySyntax' => true]);
         $newCode = $printer->printFormatPreserving($this->newStmts, $this->oldStmts, $this->oldTokens);
 
         file_put_contents($path, $newCode);

--- a/src/SimpleTestToMockeryVisitor.php
+++ b/src/SimpleTestToMockeryVisitor.php
@@ -390,13 +390,14 @@ class SimpleTestToMockeryVisitor extends NodeVisitorAbstract
 
     /**
      * @param Node\Expr\MethodCall $node
-     * @return array
+     * @return Node\Expr\MethodCall
      * @throws \Exception
      */
     private function convertReturn(Node\Expr\MethodCall $node)
     {
         if (count($node->args) <= 3) {
-            $method_name = (string) $node->args[0]->value->value;
+            $method_name_expr = $node->args[0]->value;
+            $method_name = (string) $method_name_expr->value;
             $returned_value = $node->args[1];
             $arguments = [];
             if (isset($node->args[2])) {
@@ -407,45 +408,70 @@ class SimpleTestToMockeryVisitor extends NodeVisitorAbstract
                 }
             }
 
-            $returns = $this->generateMockeryMock($node->var, $method_name, $arguments);
-            $returns []= new Node\Expr\MethodCall(
-                new Node\Expr\Variable($this->getMockedVarName($node->var, $method_name)),
-                'andReturns',
-                [$returned_value->value]
+            $do_we_care_about_arguments = count($arguments) > 0;
+
+            if ($do_we_care_about_arguments) {
+                return new Node\Expr\MethodCall(
+                    new Node\Expr\MethodCall(
+                        new Node\Expr\MethodCall(
+                            $node->var,
+                            'allows'
+                        ),
+                        $method_name,
+                        $arguments
+                    ),
+                    'andReturns',
+                    [$returned_value->value]
+                );
+            }
+
+            return new Node\Expr\MethodCall(
+                $node->var,
+                'allows',
+                [
+                    new Node\Arg(
+                        new Node\Expr\Array_(
+                            [
+                                new Node\Expr\ArrayItem($returned_value->value, $method_name_expr)
+                            ]
+                        )
+                    )
+                ]
             );
-            return $returns;
         }
-        throw new \Exception("Un-managed number of arguments for expectCallCount at L".$node->getLine());
+        throw new \Exception("Un-managed number of arguments for setReturnValue at L".$node->getLine());
     }
 
     /**
      * @param Node\Expr\MethodCall $node
-     * @return array
+     * @return Node\Expr\MethodCall
      * @throws \Exception
      */
     private function convertExpectOnce(Node\Expr\MethodCall $node)
     {
         if (count($node->args) <= 3) {
             $method_name = (string) $node->args[0]->value->value;
-            $method_args = [];
+            $arguments = [];
             if (isset($node->args[1])) {
                 if ($node->args[1]->value instanceof Node\Expr\ConstFetch && (string) $node->args[1]->value->name->parts[0] === 'false') {
-                    $method_args = [];
+                    $arguments = [];
                 } elseif (isset($node->args[1]->value->items)) {
-                    $method_args = $node->args[1]->value->items;
+                    $arguments = $node->args[1]->value->items;
                 } else {
                     throw new \Exception("Unhandled construction at  L".$node->getLine());
                 }
             }
 
-            $returns = $this->generateMockeryMock($node->var, $method_name, $method_args);
-            $returns []= new Node\Expr\MethodCall(
-                new Node\Expr\Variable($this->getMockedVarName($node->var, $method_name)),
-                'once'
+            return new Node\Expr\MethodCall(
+                new Node\Expr\MethodCall(
+                    $node->var,
+                    'expects'
+                ),
+                $method_name,
+                $arguments
             );
-            return $returns;
         }
-        throw new \Exception("Un-managed number of arguments for expectCallCount at L".$node->getLine());
+        throw new \Exception("Un-managed number of arguments for expectOnce at L".$node->getLine());
     }
 
     /**
@@ -469,7 +495,7 @@ class SimpleTestToMockeryVisitor extends NodeVisitorAbstract
             );
             return $returns;
         }
-        throw new \Exception("Un-managed number of arguments for expectCallCount at L".$node->getLine());
+        throw new \Exception("Un-managed number of arguments for expectNever at L".$node->getLine());
     }
 
     /**

--- a/tests/_expected/MockTest.php
+++ b/tests/_expected/MockTest.php
@@ -31,30 +31,24 @@ class MockTest
     public function testMethodsAreConverted()
     {
         $foo = \Mockery::spy(Foo::class);
-        $foo_getTrackerById = $foo->shouldReceive('getTrackerById');
-        $foo_getTrackerById->with('param1', 'param2');
-        $foo_getTrackerById->andReturns('result');
+        $foo->allows()->getTrackerById('param1', 'param2')->andReturns('result');
     }
 
     public function itConvertsAlsoItMethods()
     {
         $foo = \Mockery::spy(Foo::class);
-        $foo_searchAncestorIds = $foo->shouldReceive('searchAncestorIds');
-        $foo_searchAncestorIds->with('param1');
-        $foo_searchAncestorIds->once();
-        $foo_searchAncestorIds->andReturns('result');
+        $foo->expects()->searchAncestorIds('param1');
+        $foo->allows(['searchAncestorIds' => 'result']);
     }
 
     public function testWhithOnceLaterInTheStack()
     {
         $foo = \Mockery::spy(Foo::class);
-        $foo_searchAncestorIds = $foo->shouldReceive('searchAncestorIds');
-        $foo_searchAncestorIds->andReturns('result');
+        $foo->allows(['searchAncestorIds' => 'result']);
 
         buildOtherStuff();
-        $foo_searchAncestorIds->with('param1');
 
-        $foo_searchAncestorIds->once();
+        $foo->expects()->searchAncestorIds('param1');
     }
 
     public function testWhithMockHelper()
@@ -65,20 +59,17 @@ class MockTest
     public function testPartialMock()
     {
         $baz = \Mockery::mock(Baz::class)->makePartial()->shouldAllowMockingProtectedMethods();
-        $baz_meth1 = $baz->shouldReceive('meth1');
-        $baz_meth1->once();
+        $baz->expects()->meth1();
     }
 
     public function testWithPartialMock()
     {
         $baz = \Mockery::mock(Food\Truck::class)->makePartial()->shouldAllowMockingProtectedMethods();
-        $baz_burger = $baz->shouldReceive('burger');
-        $baz_burger->once();
+        $baz->expects()->burger();
     }
 
     public function testWhenInitialisationIsDoneInSetUp()
     {
-        $this_tracker_getId = $this->tracker->shouldReceive('getId');
-        $this_tracker_getId->andReturns(123);
+        $this->tracker->allows(['getId' => 123]);
     }
 }


### PR DESCRIPTION
Instead of accumulating a bunch of variables like $foo_methodName1 use the
allows()/expects() syntax in order to not clutter too much the refactored
tests.

http://docs.mockery.io/en/latest/reference/alternative_should_receive_syntax.html